### PR TITLE
Fix unused decision variables handling

### DIFF
--- a/ommx_gurobipy_adapter/adapter.py
+++ b/ommx_gurobipy_adapter/adapter.py
@@ -107,7 +107,7 @@ class OMMXGurobipyAdapter(SolverAdapter):
                 )
 
             entries = {}
-            for var in self.instance.decision_variables:
+            for var in self.instance.used_decision_variables:
                 variable = data.getVarByName(str(var.id))
                 if variable:
                     entries[var.id] = variable.X
@@ -117,7 +117,7 @@ class OMMXGurobipyAdapter(SolverAdapter):
 
     def _set_decision_variables(self):
         """Set up decision variables in the Gurobi model."""
-        for var in self.instance.decision_variables:
+        for var in self.instance.used_decision_variables:
             if var.kind == DecisionVariable.BINARY:
                 self.model.addVar(name=str(var.id), vtype=GRB.BINARY)
             elif var.kind == DecisionVariable.INTEGER:
@@ -146,7 +146,7 @@ class OMMXGurobipyAdapter(SolverAdapter):
             str(id): var
             for var, id in zip(
                 self.model.getVars(),
-                (var.id for var in self.instance.decision_variables),
+                (var.id for var in self.instance.used_decision_variables),
             )
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: Apache Software License",
 ]
-dependencies = ["gurobipy>=12.0.1", "ommx>=2.0.0rc1,<3.0.0"]
+dependencies = ["gurobipy>=12.0.1", "ommx>=2.0.3,<3.0.0"]
 
 [project.urls]
 Repository = "https://github.com/Jij-Inc/ommx-gurobipy-adapter"

--- a/tests/test_ommx_gurobipy.py
+++ b/tests/test_ommx_gurobipy.py
@@ -64,7 +64,7 @@ def test_partial_evaluate():
     instance = Instance.from_components(
         decision_variables=x,
         objective=x[0] + x[1] + x[2],
-        constraints=[(x[0] + x[1] + x[2] <= 1).set_id(0)],  # one-hot constraint
+        constraints=[(x[0] + x[1] + x[2] <= 1).set_id(0)],
         sense=Instance.MINIMIZE,
     )
     assert instance.used_decision_variables == x

--- a/tests/test_ommx_gurobipy.py
+++ b/tests/test_ommx_gurobipy.py
@@ -59,6 +59,7 @@ def test_multi_objective_handling():
 
 
 def test_partial_evaluate():
+    """Test that the adapter correctly handles partially evaluated instances with used_decision_variables"""
     x = [DecisionVariable.binary(i, name="x", subscripts=[i]) for i in range(3)]
     instance = Instance.from_components(
         decision_variables=x,
@@ -84,6 +85,7 @@ def test_partial_evaluate():
 
 
 def test_relax_constraint():
+    """Test that the adapter correctly handles constraint relaxation and irrelevant variable identification"""
     x = [DecisionVariable.binary(i, name="x", subscripts=[i]) for i in range(3)]
     instance = Instance.from_components(
         decision_variables=x,

--- a/tests/test_ommx_gurobipy.py
+++ b/tests/test_ommx_gurobipy.py
@@ -56,3 +56,46 @@ def test_multi_objective_handling():
     # Should maximize x to its upper bound
     assert solution.state.entries[1] == pytest.approx(1)
     assert solution.objective == pytest.approx(1)
+
+def test_partial_evaluate():
+    x = [DecisionVariable.binary(i, name="x", subscripts=[i]) for i in range(3)]
+    instance = Instance.from_components(
+        decision_variables=x,
+        objective=x[0] + x[1] + x[2],
+        constraints=[(x[0] + x[1] + x[2] <= 1).set_id(0)],  # one-hot constraint
+        sense=Instance.MINIMIZE,
+    )
+    assert instance.used_decision_variables == x
+    partial = instance.partial_evaluate({0: 1})
+    # x[0] is no longer present in the problem
+    assert partial.used_decision_variables == x[1:]
+
+    solution = OMMXGurobipyAdapter.solve(partial)
+    assert [var.value for var in solution.decision_variables] == [1, 0, 0]
+
+    partial = instance.partial_evaluate({1: 1})
+    solution = OMMXGurobipyAdapter.solve(partial)
+    assert [var.value for var in solution.decision_variables] == [0, 1, 0]
+
+    partial = instance.partial_evaluate({2: 1})
+    solution = OMMXGurobipyAdapter.solve(partial)
+    assert [var.value for var in solution.decision_variables] == [0, 0, 1]
+
+
+def test_relax_constraint():
+    x = [DecisionVariable.binary(i, name="x", subscripts=[i]) for i in range(3)]
+    instance = Instance.from_components(
+        decision_variables=x,
+        objective=x[0] + x[1],
+        constraints=[(x[0] + 2 * x[1] <= 1).set_id(0), (x[1] + x[2] <= 1).set_id(1)],
+        sense=Instance.MINIMIZE,
+    )
+
+    assert instance.used_decision_variables == x
+    instance.relax_constraint(1, "relax")
+    # id for x[2] is listed as irrelevant
+    assert instance.decision_variable_analysis().irrelevant() == {x[2].id}
+
+    solution = OMMXGurobipyAdapter.solve(instance)
+    # x[2] is still present as part of the evaluate/decoding process but has a value of 0
+    assert [var.value for var in solution.decision_variables] == [0, 0, 0]

--- a/tests/test_ommx_gurobipy.py
+++ b/tests/test_ommx_gurobipy.py
@@ -57,6 +57,7 @@ def test_multi_objective_handling():
     assert solution.state.entries[1] == pytest.approx(1)
     assert solution.objective == pytest.approx(1)
 
+
 def test_partial_evaluate():
     x = [DecisionVariable.binary(i, name="x", subscripts=[i]) for i in range(3)]
     instance = Instance.from_components(


### PR DESCRIPTION
## 概要
- `decision_variables` を `used_decision_variables` に変更
- ommx依存関係を2.0.3にアップデート
- 部分評価とconstraint relaxationのテストを追加

## 変更内容
- アダプターで使用中の決定変数のみを処理するように修正
- 新しいommxバージョンに対応
- 新機能のテストケースを追加

🤖 Generated with [Claude Code](https://claude.ai/code)